### PR TITLE
Use HTTP instead of TCP mode and add a healthcheck route

### DIFF
--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -1,6 +1,6 @@
 defaults
-  mode tcp
-  option tcplog
+  mode http
+  option httplog
   log /dev/log local0
   timeout connect 5000ms
   timeout client 60000ms
@@ -8,6 +8,7 @@ defaults
 
 frontend http
   bind *:80
+  monitor-uri /healthcheck/haproxy
   default_backend tls
 
 backend tls


### PR DESCRIPTION
From the [HAProxy docs](https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#monitor-uri):

> When an HTTP request referencing <uri> will be received on a frontend,
HAProxy will not forward it nor log it, but instead will return either
"HTTP/1.0 200 OK" or "HTTP/1.0 503 Service unavailable", depending on failure
conditions defined with "monitor fail". This is normally enough for any
front-end HTTP probe to detect that the service is UP and running without
forwarding the request to a backend server. Note that the HTTP method, the
version and all headers are ignored, but the request must at least be valid
at the HTTP level. This keyword may only be used with an HTTP-mode frontend.

This will enable any upstream components to monitor the health of these containers without sending a request downstream (e.g. using the 8000:80 example from the README):

```
$ curl localhost:8000/healthcheck/haproxy
<html><body><h1>200 OK</h1>
Service ready.
</body></html>
```