### PR TITLE
Store generated config in a new tmp subdirectory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ COPY haproxy.cfg.template /usr/local/etc/haproxy/haproxy.cfg.template
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 EXPOSE 80
 
-CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg", "-d"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/tmp/haproxy.cfg", "-d"]
 ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,8 @@ if [[ ! "${HAPROXY_BACKED_OPTIONS}" ]]; then
   export HAPROXY_BACKED_OPTIONS="\"${REMOTE_HOST}:${REMOTE_PORT}\" ssl sni str(${SNI_HOSTNAME}) verify required ${HOST_VERIFICATION} ca-file \"${CA_FILE}\" no-sslv3 no-tlsv10"
 fi
 
-cat /usr/local/etc/haproxy/haproxy.cfg.template | envsubst > /usr/local/etc/haproxy/haproxy.cfg
+mkdir -p /usr/local/etc/haproxy/tmp
+cat /usr/local/etc/haproxy/haproxy.cfg.template | envsubst > /usr/local/etc/haproxy/tmp/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
This makes it easier to optionally run the container with a read-only root filesystem by storing the config file that's generated by substituting values in the initial config template in `/usr/local/etc/haproxy/tmp` rather than the root `/usr/local/etc/haproxy` folder:

```bash
docker run --rm -it \
    -e REMOTE_HOST=google.com \
    -e CERT_NAME="*.google.com" \
    -p 8000:80 \
    --read-only \
    --tmpfs "/usr/local/etc/haproxy/tmp" \
    --tmpfs "/run" \
    bugcrowd/remote-tls-terminator
```