### PR TITLE
Add tcp mode option + customizable healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk add --no-cache \
 
 COPY haproxy.cfg.template /usr/local/etc/haproxy/haproxy.cfg.template
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-EXPOSE 80
 
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/tmp/haproxy.cfg", "-d"]
 ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Options
 -------
 
 *   REMOTE_HOST = The remote host you wish to connect to
-*   REMOTE_PORT = The port on the remote host you wish to connect to. Defaults to 443
-*   CERT_NAME = The name on the certificate to verify the host against. If no certificate name is provide no host verification is performed
+*   REMOTE_PORT = The port on the remote host you wish to connect to. Defaults to `443`
+*   BIND_TUNNEL_PORT = The port to bind the tunnel to inside the container. Defaults to `80`
+*   PROXY_MODE = The proxy mode to run HAProxy in. Defaults to `http`. Alternative value is `tcp`
+*   HEALTHCHECK = Healthcheck route (e.g. `/healthcheck/haproxy`). This is a healthcheck for the HAProxy process. Not the upstream service. When run in `http` mode the healthcheck is served inline on the `BIND_TUNNEL_PORT` port. When run in `tcp` mode the healthcheck is served on port `79`. Default is disabled (any value will enable).
+*   CERT_NAME = The name on the certificate to verify the host against. If no certificate name is provided no host verification is performed
 *   CA_FILE = A list of Certificate Authorities to verify the certificate against. Defaults to system CA's
-*   SNI_HOSTNAME = The hostname used as the Server Name Indicator. Defaults to REMOTE_HOST
+*   SNI_HOSTNAME = The hostname used as the Server Name Indicator. Defaults to `REMOTE_HOST`
 *   HAPROXY_BACKED_OPTIONS = Override all HAProxy backend options. If this option is set then all other options set are discarded. Defaults to `"${REMOTE_HOST}:${REMOTE_PORT}" ssl sni "${SNI_HOSTNAME}" verify required ${HOST_VERIFICATION} ca-file "${CA_FILE}" no-sslv3 no-tlsv10`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,31 @@ if [[ ! "${REMOTE_PORT}" ]]; then
   export REMOTE_PORT="443"
 fi
 
+if [[ ! "${BIND_TUNNEL_PORT}" ]]; then
+  export BIND_TUNNEL_PORT="80"
+fi
+
+if [[ ! "${PROXY_MODE}" ]]; then
+  export PROXY_MODE="http"
+fi
+
+if [[ "${HEALTHCHECK}" ]]; then
+  if [[ "${PROXY_MODE}" == "tcp" ]]; then
+    export HEALTHCHECK_BLOCK="$(cat <<EOF
+frontend healthcheck
+  mode http
+  option httplog
+  bind *:79
+  monitor-uri ${HEALTHCHECK}
+EOF
+)"
+  fi
+
+  if [[ "${PROXY_MODE}" == "http" ]]; then
+    export HEALTHCHECK_INLINE="monitor-uri ${HEALTHCHECK}"
+  fi
+fi
+
 if [[ "${CERT_NAME}" ]]; then
   export HOST_VERIFICATION="verifyhost \"${CERT_NAME}\""
 fi

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -1,15 +1,18 @@
 defaults
-  mode http
-  option httplog
   log /dev/log local0
   timeout connect 5000ms
   timeout client 60000ms
   timeout server 60000ms
 
-frontend http
-  bind *:80
-  monitor-uri /healthcheck/haproxy
-  default_backend tls
+${HEALTHCHECK_BLOCK}
 
-backend tls
+frontend tls_tunnel
+  mode ${PROXY_MODE}
+  option ${PROXY_MODE}log
+  bind *:${BIND_TUNNEL_PORT}
+  default_backend tls_backend
+  ${HEALTHCHECK_INLINE}
+
+backend tls_backend
+  mode ${PROXY_MODE}
   server srv ${HAPROXY_BACKED_OPTIONS}


### PR DESCRIPTION
Adding a few envs to customize behavior:
*   BIND_TUNNEL_PORT = The port to bind the tunnel to inside the container. Defaults to `80`
*   PROXY_MODE = The proxy mode to run HAProxy in. Defaults to `http`. Alternative value is `tcp`
*   HEALTHCHECK = Healthcheck route (e.g. `/healthcheck/haproxy`). This is a healthcheck for the HAProxy process. Not the upstream service. When run in `http` mode the healthcheck is served inline on the `BIND_TUNNEL_PORT` port. When run in `tcp` mode the healthcheck is served on port `79`. Default is disabled (any value will enable).
